### PR TITLE
Assert that Something can not be instantiated with a None value.

### DIFF
--- a/optional/something.py
+++ b/optional/something.py
@@ -4,6 +4,9 @@ from .exceptions import FlatMapFunctionDoesNotReturnOptionalException
 
 class Something(AbstractOptional):
     def __init__(self, value, optional):
+        if value is None:
+            raise ValueError('Invalid value for Something: None')
+
         self.__value = value
         self.__optional = optional
 

--- a/test/test_optional.py
+++ b/test/test_optional.py
@@ -1,4 +1,4 @@
-import unittest
+from unittest import TestCase
 
 from optional import Optional
 from optional.exceptions import (
@@ -7,7 +7,7 @@ from optional.exceptions import (
 )
 
 
-class TestOptional(unittest.TestCase):
+class TestOptional(TestCase):
 
     def test_can_instantiate(self):
         Optional.of(None)

--- a/test/test_something.py
+++ b/test/test_something.py
@@ -1,0 +1,22 @@
+from unittest import TestCase
+
+from optional import Optional
+from optional.something import Something
+
+
+class TestSomething(TestCase):
+
+    def test_can_not_instantiate_with_a_none_value(self):
+        with self.assertRaises(ValueError) as cm:
+            Something(value=None, optional=Optional)
+
+        self.assertEqual(
+            'Invalid value for Something: None',
+            str(cm.exception)
+        )
+
+    def test_can_instantiate_with_any_other_value(self):
+        self.assertEqual(
+            Optional.of(23),
+            Something(value=23, optional=Optional)
+        )


### PR DESCRIPTION
- If using this library properly, this is not possible and
  the assertion guarantees that we weren't.
- If using this library improperly, it's now impossible to
  end up with a Something of None.