### PR TITLE
DO NOT MERGE: Implement a default value on `get`.

### DIFF
--- a/optional/nothing.py
+++ b/optional/nothing.py
@@ -6,10 +6,13 @@ class Nothing(AbstractOptional):
     def is_present(self):
         return False
 
-    def get(self):
-        raise OptionalAccessOfEmptyException(
-            "You cannot call get on an empty optional"
-        )
+    def get(self, default_value=None):
+        if default_value is not None:
+            return default_value
+        else:
+            raise OptionalAccessOfEmptyException(
+                "You cannot call get on an empty optional"
+            )
 
     def if_present(self, consumer):
         return self

--- a/optional/something.py
+++ b/optional/something.py
@@ -13,7 +13,7 @@ class Something(AbstractOptional):
     def is_present(self):
         return True
 
-    def get(self):
+    def get(self, default_value=None):
         return self.__value
 
     def if_present(self, consumer):

--- a/test/test_optional.py
+++ b/test/test_optional.py
@@ -203,3 +203,16 @@ class TestOptional(object):
 
     def test_can_instantiate_an_empty_optional_via_the_zero_arity_of(self):
         assert Optional.of() == Optional.empty()
+
+    def test_get_on_a_populated_optional_ignores_default_value(self):
+        optional = Optional.of("thing")
+        assert optional.get("pants") == "thing"
+
+    def test_get_on_an_empty_optional_returns_default_value(self):
+        optional = Optional.empty()
+        assert optional.get("pants") == "pants"
+
+    def test_get_using_default_on_an_empty_optional_may_not_use_none(self):
+        optional = Optional.empty()
+        with pytest.raises(OptionalAccessOfEmptyException):
+            optional.get(None)


### PR DESCRIPTION
I looked at making get() play nice with a default value. In doing so, I think I've decided this is a bad idea and we should opt for get_or_default().