### PR TITLE
Implement Python 2 and 3 magic truthiness methods.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,11 @@ $ pip install optional.py
     thing = some_func_returning_an_optional()
     if thing.is_present():
     ```
-
+    or, alternatively: :smirk_cat:
+    ```python
+    thing = some_func_returning_an_optional()
+    if thing:
+    ```
 5. You can check if its empty:
 
     instead of: :scream_cat:
@@ -96,6 +100,11 @@ $ pip install optional.py
     ```python
     thing = some_func_returning_an_optional()
     if thing.is_empty():
+    ```
+    or, alternatively: :smirk_cat:
+    ```python
+    thing = some_func_returning_an_optional()
+    if not thing:
     ```
 
 
@@ -203,7 +212,7 @@ $ pip install optional.py
         thing = some_func_returning_an_empty_optional()
         if thing.is_empty():
             thing = Optional.of("pants")
-        print(thing.get()) # Prints "pants"   
+        print(thing.get()) # Prints "pants"
 
     ```
     you can do: :heart_eyes_cat:

--- a/optional/abstract_optional.py
+++ b/optional/abstract_optional.py
@@ -6,11 +6,8 @@ from .compatible_abc import CompatibleABC
 class AbstractOptional(CompatibleABC):
 
     @abstractmethod
-    def is_present(self):
-        pass
-
     def is_empty(self):
-        return not self.is_present()
+        pass
 
     @abstractmethod
     def get(self):
@@ -43,3 +40,8 @@ class AbstractOptional(CompatibleABC):
     @abstractmethod
     def flat_map(self, func):
         pass
+
+    def is_present(self):
+        return not self.is_empty()
+
+    __bool__ = __nonzero__ = is_present

--- a/optional/nothing.py
+++ b/optional/nothing.py
@@ -7,8 +7,8 @@ class Nothing(AbstractOptional):
     def __init__(self, optional):
         self.__optional = optional
 
-    def is_present(self):
-        return False
+    def is_empty(self):
+        return True
 
     def get(self):
         raise OptionalAccessOfEmptyException(

--- a/optional/something.py
+++ b/optional/something.py
@@ -10,8 +10,8 @@ class Something(AbstractOptional):
         self.__value = value
         self.__optional = optional
 
-    def is_present(self):
-        return True
+    def is_empty(self):
+        return False
 
     def get(self):
         return self.__value

--- a/test/test_optional.py
+++ b/test/test_optional.py
@@ -238,3 +238,12 @@ class TestOptional(object):
 
         with pytest.raises(RandomDomainException):
             optional.get_or_raise(RandomDomainException())
+
+    def test_populated_optionals_are_truthy(self):
+        assert Optional.of('foo')
+
+    def test_populated_optionals_are_truthy_even_if_their_value_is_falsy(self):
+        assert Optional.of(False)
+
+    def test_empty_optionals_are_falsy(self):
+        assert not Optional.empty()


### PR DESCRIPTION
Implementation detail - by swapping the abstract-ness of `is_present` and `is_empty`, it's easier to define the `__bool__` (Python 3) and `__nonzero__` (Python 2) methods.

Of course, this is mostly moot if we end up removing `is_present` and `is_empty`.