### PR TITLE
Formatter fixes

### DIFF
--- a/optional/exceptions.py
+++ b/optional/exceptions.py
@@ -1,5 +1,3 @@
-
-
 class OptionalAccessOfEmptyException(Exception):
     pass
 

--- a/test/test_optional.py
+++ b/test/test_optional.py
@@ -3,7 +3,7 @@ import pytest
 from optional import Optional
 from optional.exceptions import (
     OptionalAccessOfEmptyException,
-    FlatMapFunctionDoesNotReturnOptionalException
+    FlatMapFunctionDoesNotReturnOptionalException,
 )
 
 
@@ -66,7 +66,7 @@ class TestOptional(object):
     def test_will_run_or_else_from_if_present_when_not_present(self):
         scope = {
             'if_seen': False,
-            'else_seen': False
+            'else_seen': False,
         }
 
         def some_thing_consumer(thing):
@@ -83,7 +83,7 @@ class TestOptional(object):
     def test_will_not_run_or_else_from_if_present_when_not_empty(self):
         scope = {
             'if_seen': False,
-            'else_seen': False
+            'else_seen': False,
         }
 
         def some_thing_consumer(thing):

--- a/test/test_optional.py
+++ b/test/test_optional.py
@@ -6,6 +6,7 @@ from optional.exceptions import (
     FlatMapFunctionDoesNotReturnOptionalException
 )
 
+
 class TestOptional(object):
 
     def test_can_instantiate(self):


### PR DESCRIPTION
Ran [black](https://black.readthedocs.io/en/stable/) over the code. I didn't take the prefer double quoted strings and some whitespace changes but these seemed positive.