### PR TITLE
Use consistent parameter names throughout

### DIFF
--- a/optional/abstract_optional.py
+++ b/optional/abstract_optional.py
@@ -18,7 +18,7 @@ class AbstractOptional(CompatibleABC):
         pass
 
     @abstractmethod
-    def get_or_raise(self, exception):
+    def get_or_raise(self, raiseable):
         pass
 
     @abstractmethod
@@ -26,7 +26,7 @@ class AbstractOptional(CompatibleABC):
         pass
 
     @abstractmethod
-    def or_else(self, procedure):
+    def or_else(self, supplier):
         pass
 
     @abstractmethod


### PR DESCRIPTION
`pylint` complains about this. Easy fix