### PR TITLE
Explicitly set Optional to be exported

### DIFF
--- a/optional/__init__.py
+++ b/optional/__init__.py
@@ -1,1 +1,3 @@
 from .optional import Optional
+
+__all__ = ["Optional"]


### PR DESCRIPTION
- This gets rid of a lint warning

Before:
```sh
$ ruff .           
Found 1 error(s).
optional/__init__.py:1:1: F401 `optional.Optional` imported but unused and missing from `__all__`
```

After:
```sh
$ ruff .       
                                                                                                                        
```